### PR TITLE
app.js path should be absolute

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
   entry: './src/index.tsx',
   output: {
     filename: 'app.js',
+    publicPath: '/'
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js'],


### PR DESCRIPTION
If someone call a subpage directly the app breaks because app.js is tried to loaded from subpages path e.g. /about/app.js

this could be fixed by adding output.publicPath to webpack.config